### PR TITLE
feature: define blog slug in frontmatter

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -36,9 +36,10 @@ exports.onCreateNode = ({node, boundActionCreators, getNode}) => {
   let slug;
   switch (node.internal.type) {
     case `MarkdownRemark`:
+      const fmSlug = (node.frontmatter && node.frontmatter.slug) ? node.frontmatter.slug : false
       const fileNode = getNode(node.parent);
       const [basePath, name] = fileNode.relativePath.split('/');
-      slug = `/${basePath}/${name}/`;
+      slug = fmSlug ? `/${basePath}/${fmSlug}/` : `/${basePath}/${name}/`;
       break;
   }
   if (slug) {


### PR DESCRIPTION
Modify `gatsby-node.js` so that it reads in frontmatter slug and uses it for blog URL. If frontmatter is not defined or slug is not defined it will default to file path for slug (current behavior).

E.g. on the demo the first blog post is `demo.com/blog/2017-04-18--welcoming/` by adding `slug` to front matter like
```
---
title: 'Article #2'
tags:
  - test
slug: 2017-04-18/my-article
---
```
the new url would be `demo.com/blog/2017-04-18/my-article`
