### PR TITLE
active tag links back to blog page

### DIFF
--- a/src/components/TagsCard/TagsCard.tsx
+++ b/src/components/TagsCard/TagsCard.tsx
@@ -24,11 +24,12 @@ export default (props: TagsCardProps) => {
             const activeStyle = {
               fontWeight: "700",
             };
+            const tagLink = isActive ? `/blog` : `/blog/tags/${tag.fieldValue}/`;
             return (
               <List.Item as="a" key={tag.fieldValue}>
                 <List.Icon name="tag" color={isActive ? "blue" : null} />
                 <List.Content style={isActive ? activeStyle : null}>
-                  <props.Link to={`/blog/tags/${tag.fieldValue}/`}>
+                  <props.Link to={tagLink}>
                     {tag.fieldValue} ({tag.totalCount})
                   </props.Link>
                 </List.Content>

--- a/src/components/TagsCard/__snapshots__/TagsCard.test.tsx.snap
+++ b/src/components/TagsCard/__snapshots__/TagsCard.test.tsx.snap
@@ -59,7 +59,7 @@ ShallowWrapper {
                                         }
                               >
                                         <LinkStub
-                                                  to="/blog/tags/tag01/"
+                                                  to="/blog"
                                         >
                                                   tag01
                                                    (
@@ -158,7 +158,7 @@ ShallowWrapper {
                                     }
                         >
                                     <LinkStub
-                                                to="/blog/tags/tag01/"
+                                                to="/blog"
                                     >
                                                 tag01
                                                  (
@@ -231,7 +231,7 @@ ShallowWrapper {
                                 }
                 >
                                 <LinkStub
-                                                to="/blog/tags/tag01/"
+                                                to="/blog"
                                 >
                                                 tag01
                                                  (
@@ -303,7 +303,7 @@ ShallowWrapper {
                     }
 >
                     <LinkStub
-                                        to="/blog/tags/tag01/"
+                                        to="/blog"
                     >
                                         tag01
                                          (
@@ -333,7 +333,7 @@ ShallowWrapper {
                   "nodeType": "function",
                   "props": Object {
                     "children": <LinkStub
-                      to="/blog/tags/tag01/"
+                      to="/blog"
 >
                       tag01
                        (
@@ -356,7 +356,7 @@ ShallowWrapper {
                         2,
                         ")",
                       ],
-                      "to": "/blog/tags/tag01/",
+                      "to": "/blog",
                     },
                     "ref": null,
                     "rendered": Array [
@@ -573,7 +573,7 @@ ShallowWrapper {
                                                 }
                                     >
                                                 <LinkStub
-                                                            to="/blog/tags/tag01/"
+                                                            to="/blog"
                                                 >
                                                             tag01
                                                              (
@@ -672,7 +672,7 @@ ShallowWrapper {
                                           }
                             >
                                           <LinkStub
-                                                        to="/blog/tags/tag01/"
+                                                        to="/blog"
                                           >
                                                         tag01
                                                          (
@@ -745,7 +745,7 @@ ShallowWrapper {
                                     }
                   >
                                     <LinkStub
-                                                      to="/blog/tags/tag01/"
+                                                      to="/blog"
                                     >
                                                       tag01
                                                        (
@@ -817,7 +817,7 @@ ShallowWrapper {
                       }
 >
                       <LinkStub
-                                            to="/blog/tags/tag01/"
+                                            to="/blog"
                       >
                                             tag01
                                              (
@@ -847,7 +847,7 @@ ShallowWrapper {
                     "nodeType": "function",
                     "props": Object {
                       "children": <LinkStub
-                        to="/blog/tags/tag01/"
+                        to="/blog"
 >
                         tag01
                          (
@@ -870,7 +870,7 @@ ShallowWrapper {
                           2,
                           ")",
                         ],
-                        "to": "/blog/tags/tag01/",
+                        "to": "/blog",
                       },
                       "ref": null,
                       "rendered": Array [


### PR DESCRIPTION
ux feels more natural when the link of the active tag links back to blog page or "turns off" the selected tag