### PR TITLE
meta charset declaration should be in the first 1024 byte

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -22,9 +22,9 @@ export default (props: HtmlProps) => {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
         {props.headComponents}
         <title>My website</title>
-        <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
         <meta
           name="viewport"


### PR DESCRIPTION
```
Always declare the encoding of your document using a meta element with a charset attribute,  
or using the http-equiv and content attributes (called a pragma directive). The declaration should  
fit completely within the first 1024 bytes at the start of the file, so it's best to put it immediately  
after the opening head tag.
```
https://www.w3.org/International/questions/qa-html-encoding-declarations.en  
😄 