### PR TITLE
Fix the test for the header component

### DIFF
--- a/src/components/HeaderMenu/HeaderMenu.test.tsx
+++ b/src/components/HeaderMenu/HeaderMenu.test.tsx
@@ -74,7 +74,7 @@ describe("HeaderMenu component", () => {
         pathname=""
         dispatch={dispatchMock} />,
     );
-    wrapper.find(".mobile .only").simulate("click");
+    wrapper.find(".mobile.only").simulate("click");
     expect(dispatchMock.mock.calls.length).toBe(1);
   });
 


### PR DESCRIPTION
The selector `.mobile .only` does not exist, but `.mobile.only` does.