### PR TITLE
test: fix selector for mobile only burger menu

### DIFF
--- a/src/components/HeaderMenu/HeaderMenu.test.tsx
+++ b/src/components/HeaderMenu/HeaderMenu.test.tsx
@@ -74,7 +74,7 @@ describe("HeaderMenu component", () => {
         pathname=""
         dispatch={dispatchMock} />,
     );
-    wrapper.find(".mobile .only").simulate("click");
+    wrapper.find(".mobile.only").simulate("click");
     expect(dispatchMock.mock.calls.length).toBe(1);
   });
 


### PR DESCRIPTION
Tests are failing because of an issue with the burger menu selector in the mobile only view.

This PR fixes this.