### PR TITLE
Update description in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-starter",
   "version": "1.0.0",
-  "description": "Gatsby 1.0 starter",
+  "description": "Gatsby 2 starter",
   "author": "fabien0102 <fabien0102@gmail.com>",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
It's confusing when in the Gatsby-Plugin-overview Gatsby-Starter is described with "Gatsby 1.0 starter": https://www.gatsbyjs.org/starters/?d=gatsby-plugin-typescript&v=2